### PR TITLE
Allow for executing executable commands set from the command line.  

### DIFF
--- a/h-config.sh
+++ b/h-config.sh
@@ -29,9 +29,7 @@ process_user_config() {
             # Check if modifications were made, if not, use original parameter
             [[ "$param" != "$modified_param" ]] && param=$modified_param
 
-            # Execute shell commands if present in the value
-            if [[ "$value" =~ \$\(.+\) ]]; then
-                # Evaluate the command within the value
+            if [[ "$value" =~ \$\(.*\) ]]; then
                 value=$(eval echo "$value")
             fi
             # Check if value exists before updating Settings

--- a/h-config.sh
+++ b/h-config.sh
@@ -29,6 +29,11 @@ process_user_config() {
             # Check if modifications were made, if not, use original parameter
             [[ "$param" != "$modified_param" ]] && param=$modified_param
 
+            # Execute shell commands if present in the value
+            if [[ "$value" =~ \$\(.+\) ]]; then
+                # Evaluate the command within the value
+                value=$(eval echo "$value")
+            fi
             # Check if value exists before updating Settings
             if [[ ! -z "$value" ]]; then
               if [[ "$param" == "overwrites" ]]; then


### PR DESCRIPTION
Allow any value set in the values field of the extra config argument to be executed. 

For example to set number of threads for the processor
```
amountOfThreads": $(nproc --ignore 1)
```
will execute the nproc command and subtract 1 from the value returned.